### PR TITLE
replace {{es-view}} with {{component}}

### DIFF
--- a/addon/ember-internals.js
+++ b/addon/ember-internals.js
@@ -1,9 +1,0 @@
-import Ember from 'ember';
-let require = Ember.__loader.require;
-let registerKeyword = require('ember-htmlbars/keywords').registerKeyword;
-let legacyViewKeyword = require('ember-htmlbars/keywords/view').default;
-
-export function registerKeywords() {
-  // This gives us a non-deprecated view keyword
-  registerKeyword('es-view', legacyViewKeyword);
-}

--- a/addon/templates/components/es-modal.hbs
+++ b/addon/templates/components/es-modal.hbs
@@ -1,9 +1,7 @@
 <div class="modal {{if animation 'fade'}}" tabindex="-1" role="dialog">
   <div class="modal-dialog {{sizeClass}}">
     <div class="modal-content">
-      {{#with innerComponent as |component|}}
-        {{es-view component hide="hide"}}
-      {{/with}}
+      {{component innerComponent hide="hide"}}
     </div>
   </div>
 </div>

--- a/app/initializers/ember-strap.js
+++ b/app/initializers/ember-strap.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 import 'ember-strap/router-dsl-ext';
-import { registerKeywords } from 'ember-strap/ember-internals';
-registerKeywords();
 
 let hackScrollSpy = function() {
   // Allows scroll spy to work without change URL fragment


### PR DESCRIPTION
and stop loading deprecated es-view
#9

This needs some more work. I couldn't get the dependencies to install and run the tests, but it seemed to work when I edited the files directly within our ember 2.8 project's node_modules directory. I'm also not sure how you want to peg versions etc for the addon. This is probably a breaking change because older versions won't have the `component` template helper.
